### PR TITLE
patch (docs): [agents] use the Foundry (new) API (Preview) to retrieve the agent id

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,15 +175,15 @@ Workloads build chat functionality into an application. Those interfaces usually
    ```bash
    FOUNDRY_NAME="aif${BASE_NAME}"
    FOUNDRY_PROJECT_NAME="projchat"
-   FOUNDRY_AGENT_CREATE_URL="https://${FOUNDRY_NAME}.services.ai.azure.com/api/projects/${FOUNDRY_PROJECT_NAME}/assistants?api-version=2025-05-15-preview"
+   FOUNDRY_AGENTS_URL="https://${FOUNDRY_NAME}.services.ai.azure.com/api/projects/${FOUNDRY_PROJECT_NAME}/agents?api-version=2025-11-15-preview"
 
-   echo $FOUNDRY_AGENT_CREATE_URL
+   echo $FOUNDRY_AGENTS_URL
    ```
 
 1. Get Agent ID value.
 
    ```bash
-   AGENT_ID=$(az rest -u $FOUNDRY_AGENT_CREATE_URL -m "get" --resource "https://ai.azure.com" --query 'data[0].id' -o tsv)
+   AGENT_ID=$(az rest -u $FOUNDRY_AGENTS_URL -m "get" --resource "https://ai.azure.com" --query 'data[0].id' -o tsv)
 
    echo $AGENT_ID
    ````


### PR DESCRIPTION
## Purpose
We wanted to incorporate this documentation patch to clarify a few missing steps required when working with the new Agents backend API (Preview) in Foundry (new).  This way users correctly target the new Agents API resource.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
* follow the steps and now an Agent Id is displayed in your terminal when echoing the `FOUNDRY_AGENTS_URL` env var

* Test the code
N/A

## What to Check
N/A

## Other Information
<!-- Add any other helpful information that may be needed here. -->