### PR TITLE
topic (iac): [foundry] update Azure OpenAI model from gpt-4o to gpt-4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Follow these instructions to deploy this example to your Azure subscription, try
   - The subscription must have the following quota available in the region you choose.
 
     - App Service Plans: P1v3 (AZ), 3 instances
-    - OpenAI model: GPT-4o model deployment with 50k tokens per minute (TPM) capacity
+    - OpenAI model: GPT-4.1 model deployment with 50k tokens per minute (TPM) capacity
 
 - Your deployment user must have the following permissions at the subscription scope.
 

--- a/infra-as-code/bicep/ai-foundry.bicep
+++ b/infra-as-code/bicep/ai-foundry.bicep
@@ -69,8 +69,8 @@ resource foundry 'Microsoft.CognitiveServices/accounts@2025-06-01' = {
     properties: {
       model: {
         format: 'OpenAI'
-        name: 'gpt-4o'
-        version: '2024-11-20'  // Use a model version available in your region.
+        name: 'gpt-4.1'
+        version: '2025-04-14'  // Use a model version available in your region.
       }
       versionUpgradeOption: 'NoAutoUpgrade' // Production deployments should not auto-upgrade models.  Testing compatibility is important.
     }


### PR DESCRIPTION
## WHY

gpt-4o version 2024-11-20 is scheduled for retirement on June 3, 2026. Rather than updating to a newer gpt-4o version, we're upgrading to gpt-4.1 which offers better capabilities and a longer support runway. Expected retirement for gpt-4.1 (2025-04-14) is ~Q2-Q4 2027.

## WHAT

- [x] update the deployed model from gpt-4o to gpt-4.1
- [x] update docs

## TEST

Pending end-to-end validation.

Port of azure-samples/microsoft-foundry-baseline#88